### PR TITLE
カレンダー部分の修正

### DIFF
--- a/frontend/src/components/parts/DailyDialog.tsx
+++ b/frontend/src/components/parts/DailyDialog.tsx
@@ -37,7 +37,7 @@ export const DailyDialog = ({
         <Typography sx={{ marginBottom: "10px" }}>
           {schedules.length}件の予定があります
         </Typography>
-        <Typography>{day.format("DD")}</Typography>
+        <Typography>{day.format("D")}日</Typography>
         {schedules.map((schedule: scheduleType, index: number) => (
           <DaySchedule
             key={index}

--- a/frontend/src/components/parts/DailyDialog.tsx
+++ b/frontend/src/components/parts/DailyDialog.tsx
@@ -1,9 +1,17 @@
 import { scheduleType } from "@/types/schedule";
-import { Button, Dialog, DialogActions, DialogContent } from "@mui/material";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  Typography,
+} from "@mui/material";
 import React from "react";
 import { DaySchedule } from "./DaySchedule";
+import dayjs from "dayjs";
 
 type Props = {
+  day: dayjs.Dayjs;
   schedules: scheduleType[];
   setSchedule: React.Dispatch<React.SetStateAction<scheduleType>>;
   showDialog: boolean;
@@ -11,14 +19,23 @@ type Props = {
 };
 
 export const DailyDialog = ({
+  day,
   schedules,
   setSchedule,
   showDialog,
   setShowDialog,
 }: Props) => {
   return (
-    <Dialog open={showDialog} onClose={() => setShowDialog(false)}>
+    <Dialog
+      open={showDialog}
+      onClose={() => setShowDialog(false)}
+      // sx={{ width: "100px", height: "100px" }}
+    >
       <DialogContent>
+        <Typography sx={{ marginBottom: "10px" }}>
+          {schedules.length}件の予定があります
+        </Typography>
+        <Typography>{day.format("DD")}</Typography>
         {schedules.map((schedule: scheduleType, index: number) => (
           <DaySchedule
             key={index}
@@ -29,7 +46,14 @@ export const DailyDialog = ({
         ))}
       </DialogContent>
       <DialogActions>
-        <Button onClick={() => setShowDialog(false)}>閉じる</Button>
+        <Button
+          onClick={(e) => {
+            e.stopPropagation();
+            setShowDialog(false);
+          }}
+        >
+          閉じる
+        </Button>
       </DialogActions>
     </Dialog>
   );

--- a/frontend/src/components/parts/DailyDialog.tsx
+++ b/frontend/src/components/parts/DailyDialog.tsx
@@ -1,0 +1,36 @@
+import { scheduleType } from "@/types/schedule";
+import { Button, Dialog, DialogActions, DialogContent } from "@mui/material";
+import React from "react";
+import { DaySchedule } from "./DaySchedule";
+
+type Props = {
+  schedules: scheduleType[];
+  setSchedule: React.Dispatch<React.SetStateAction<scheduleType>>;
+  showDialog: boolean;
+  setShowDialog: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+export const DailyDialog = ({
+  schedules,
+  setSchedule,
+  showDialog,
+  setShowDialog,
+}: Props) => {
+  return (
+    <Dialog open={showDialog} onClose={() => setShowDialog(false)}>
+      <DialogContent>
+        {schedules.map((schedule: scheduleType, index: number) => (
+          <DaySchedule
+            key={index}
+            schedule={schedule}
+            setSchedule={setSchedule}
+            setShowDialog={setShowDialog}
+          />
+        ))}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={() => setShowDialog(false)}>閉じる</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/frontend/src/components/parts/DailyDialog.tsx
+++ b/frontend/src/components/parts/DailyDialog.tsx
@@ -14,21 +14,23 @@ type Props = {
   day: dayjs.Dayjs;
   schedules: scheduleType[];
   setSchedule: React.Dispatch<React.SetStateAction<scheduleType>>;
-  showDialog: boolean;
-  setShowDialog: React.Dispatch<React.SetStateAction<boolean>>;
+  showDailyDialog: boolean;
+  setShowDailyDialog: React.Dispatch<React.SetStateAction<boolean>>;
+  setScheduleDialog: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 export const DailyDialog = ({
   day,
   schedules,
   setSchedule,
-  showDialog,
-  setShowDialog,
+  showDailyDialog,
+  setShowDailyDialog,
+  setScheduleDialog,
 }: Props) => {
   return (
     <Dialog
-      open={showDialog}
-      onClose={() => setShowDialog(false)}
+      open={showDailyDialog}
+      onClose={() => setShowDailyDialog(false)}
       // sx={{ width: "100px", height: "100px" }}
     >
       <DialogContent>
@@ -41,7 +43,8 @@ export const DailyDialog = ({
             key={index}
             schedule={schedule}
             setSchedule={setSchedule}
-            setShowDialog={setShowDialog}
+            setDailyDialog={setShowDailyDialog}
+            setScheduleDialog={setScheduleDialog}
           />
         ))}
       </DialogContent>
@@ -49,7 +52,7 @@ export const DailyDialog = ({
         <Button
           onClick={(e) => {
             e.stopPropagation();
-            setShowDialog(false);
+            setShowDailyDialog(false);
           }}
         >
           閉じる

--- a/frontend/src/components/parts/DaySchedule.tsx
+++ b/frontend/src/components/parts/DaySchedule.tsx
@@ -6,7 +6,8 @@ import React, { Dispatch, SetStateAction } from "react";
 type Props = {
   schedule: scheduleType;
   setSchedule: Dispatch<SetStateAction<scheduleType>>;
-  setShowDialog: Dispatch<SetStateAction<boolean>>;
+  setDailyDialog: Dispatch<SetStateAction<boolean>>;
+  setScheduleDialog: Dispatch<SetStateAction<boolean>>;
 };
 
 const ScheduleStyle = styled(Card)(({ theme }) => ({
@@ -19,7 +20,8 @@ const ScheduleStyle = styled(Card)(({ theme }) => ({
 export const DaySchedule = ({
   schedule,
   setSchedule,
-  setShowDialog,
+  setDailyDialog,
+  setScheduleDialog,
 }: Props) => {
   return (
     <ScheduleStyle>
@@ -27,8 +29,9 @@ export const DaySchedule = ({
         sx={{ background: "#EEEEEE", height: "30px" }}
         onClick={(e) => {
           e.stopPropagation();
-          setShowDialog(true);
+          setScheduleDialog(true);
           setSchedule(schedule);
+          setDailyDialog(false);
         }}
       >
         <Typography

--- a/frontend/src/components/parts/DaySchedule.tsx
+++ b/frontend/src/components/parts/DaySchedule.tsx
@@ -1,0 +1,50 @@
+import { scheduleType } from "@/types/schedule";
+import styled from "@emotion/styled";
+import { Card, Typography } from "@mui/material";
+import React, { Dispatch, SetStateAction } from "react";
+
+type Props = {
+  schedule: scheduleType;
+  setSchedule: Dispatch<SetStateAction<scheduleType>>;
+  setShowDialog: Dispatch<SetStateAction<boolean>>;
+};
+
+const ScheduleStyle = styled(Card)(({ theme }) => ({
+  marginBottom: "4px",
+  borderRadius: "5px",
+  height: "22px",
+  background: "#EEEEEE",
+}));
+
+export const DaySchedule = ({
+  schedule,
+  setSchedule,
+  setShowDialog,
+}: Props) => {
+  return (
+    <ScheduleStyle>
+      <Card
+        sx={{ background: "#EEEEEE", height: "30px" }}
+        onClick={(e) => {
+          e.stopPropagation();
+          setShowDialog(true);
+          setSchedule(schedule);
+        }}
+      >
+        <Typography
+          fontStyle={""}
+          sx={{
+            fontWeight: 400,
+            textAlign: "left",
+            marginLeft: "10px",
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+          }}
+        >
+          {schedule.title}
+        </Typography>
+      </Card>
+    </ScheduleStyle>
+  );
+};

--- a/frontend/src/components/templates/AddScheduleBar.tsx
+++ b/frontend/src/components/templates/AddScheduleBar.tsx
@@ -33,6 +33,8 @@ export const AddScheduleBar = ({ handleSaveSchedule }: Props) => {
   const { daySelected, setDaySelected, schedule, setSchedule } =
     useContext(MonthContext);
 
+  const isError = title === "" || daySelected === null;
+
   const theme = createTheme(
     {},
     jaJP // x-date-pickers translations
@@ -46,6 +48,12 @@ export const AddScheduleBar = ({ handleSaveSchedule }: Props) => {
   const onChangeTitle = (e: React.ChangeEvent<HTMLInputElement>) => {
     setTitle(e.target.value);
     setSchedule({ ...schedule, title: e.target.value });
+  };
+
+  const handleSave = () => {
+    if (isError) return;
+    handleSaveSchedule();
+    setTitle("");
   };
 
   return (
@@ -90,7 +98,7 @@ export const AddScheduleBar = ({ handleSaveSchedule }: Props) => {
           width: "120px",
           fontSize: "20px",
         }}
-        onClick={handleSaveSchedule}
+        onClick={handleSave}
       >
         追加
       </Button>

--- a/frontend/src/components/templates/AddScheduleBar.tsx
+++ b/frontend/src/components/templates/AddScheduleBar.tsx
@@ -1,4 +1,6 @@
-import { Dispatch, SetStateAction, useState } from "react";
+import { useContext, useState } from "react";
+import { MonthContext } from "@/provider/CalendarProvider";
+
 import {
   Box,
   Button,
@@ -12,7 +14,6 @@ import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
 import dayjs from "dayjs";
 import minMax from "dayjs/plugin/minMax";
 import "dayjs/locale/ja";
-import { scheduleType } from "@/types/schedule";
 
 dayjs.extend(minMax);
 dayjs.locale("ja");
@@ -22,78 +23,77 @@ class DateAdapter extends AdapterDateFns {
 }
 
 type Props = {
-  schedule: scheduleType;
-  setSchdule: Dispatch<SetStateAction<scheduleType>>;
   handleSaveSchedule: () => Promise<void>;
 };
 
-export const AddScheduleBar = ({
-  schedule,
-  setSchdule,
-  handleSaveSchedule,
-}: Props) => {
+export const AddScheduleBar = ({ handleSaveSchedule }: Props) => {
   const today = dayjs();
   const [selectedDate, setSelectedDate] = useState<dayjs.Dayjs | null>(today);
+  const [title, setTitle] = useState("");
+  const { daySelected, setDaySelected, schedule, setSchedule } =
+    useContext(MonthContext);
 
   const theme = createTheme(
     {},
     jaJP // x-date-pickers translations
   );
 
-  const onChange = (date: Date | null) => {
+  const onChangeDate = (date: Date | null) => {
     setSelectedDate(dayjs(date));
-    setSchdule({ ...schedule, date: dayjs(date) });
+    setDaySelected(dayjs(date));
+  };
+
+  const onChangeTitle = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setTitle(e.target.value);
+    setSchedule({ ...schedule, title: e.target.value });
   };
 
   return (
-    <form onSubmit={handleSaveSchedule}>
-      <Box
-        display="flex"
-        flexDirection="column"
-        alignItems="center"
-        width="320px"
-        marginTop="30px"
-      >
-        <ThemeProvider theme={theme}>
-          <LocalizationProvider
-            dateAdapter={DateAdapter}
-            dateFormats={{ monthAndYear: "yyyy年 MM月", monthShort: "MM月" }}
-          >
-            <DateCalendar
-              views={["day"]}
-              value={selectedDate?.toDate()}
-              maxDate={today.toDate()}
-              onChange={onChange}
-              sx={{ width: "100%", transform: "scale(0.8)" }}
-            />
-          </LocalizationProvider>
-        </ThemeProvider>
-        <TextField
-          size="small"
-          inputProps={{ style: { fontSize: 18 } }}
-          placeholder="予定"
-          value={schedule.title}
-          onChange={(e) => setSchdule({ ...schedule, title: e.target.value })}
-        />
-        <Button
-          size="small"
-          variant="outlined"
-          type="submit"
-          style={{
-            borderColor: "black",
-            borderRadius: "20px",
-            background: "#014A8F",
-          }}
-          sx={{
-            color: "white",
-            marginTop: "20px",
-            width: "120px",
-            fontSize: "20px",
-          }}
+    <Box
+      display="flex"
+      flexDirection="column"
+      alignItems="center"
+      width="300px"
+      marginTop="30px"
+    >
+      <ThemeProvider theme={theme}>
+        <LocalizationProvider
+          dateAdapter={DateAdapter}
+          dateFormats={{ monthAndYear: "yyyy年 MM月", monthShort: "MM月" }}
         >
-          追加
-        </Button>
-      </Box>
-    </form>
+          <DateCalendar
+            views={["day"]}
+            value={selectedDate?.toDate()}
+            onChange={onChangeDate}
+            sx={{ width: "100%", transform: "scale(0.8)" }}
+          />
+        </LocalizationProvider>
+      </ThemeProvider>
+      <TextField
+        size="small"
+        inputProps={{ style: { fontSize: 18 } }}
+        placeholder="予定"
+        value={title}
+        onChange={onChangeTitle}
+      />
+      <Button
+        size="small"
+        variant="outlined"
+        style={{
+          borderColor: "black",
+          borderRadius: "20px",
+          background: "#014A8F",
+        }}
+        sx={{
+          color: "white",
+          marginTop: "20px",
+          width: "120px",
+          fontSize: "20px",
+        }}
+        onClick={handleSaveSchedule}
+      >
+        追加
+      </Button>
+    </Box>
   );
 };

--- a/frontend/src/components/templates/AddScheduleBar.tsx
+++ b/frontend/src/components/templates/AddScheduleBar.tsx
@@ -1,0 +1,99 @@
+import { Dispatch, SetStateAction, useState } from "react";
+import {
+  Box,
+  Button,
+  TextField,
+  ThemeProvider,
+  createTheme,
+} from "@mui/material";
+import { DateCalendar, LocalizationProvider } from "@mui/x-date-pickers";
+import { jaJP } from "@mui/x-date-pickers/locales";
+import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
+import dayjs from "dayjs";
+import minMax from "dayjs/plugin/minMax";
+import "dayjs/locale/ja";
+import { scheduleType } from "@/types/schedule";
+
+dayjs.extend(minMax);
+dayjs.locale("ja");
+
+class DateAdapter extends AdapterDateFns {
+  getWeekdays = (): string[] => ["日", "月", "火", "水", "木", "金", "土"];
+}
+
+type Props = {
+  schedule: scheduleType;
+  setSchdule: Dispatch<SetStateAction<scheduleType>>;
+  handleSaveSchedule: () => Promise<void>;
+};
+
+export const AddScheduleBar = ({
+  schedule,
+  setSchdule,
+  handleSaveSchedule,
+}: Props) => {
+  const today = dayjs();
+  const [selectedDate, setSelectedDate] = useState<dayjs.Dayjs | null>(today);
+
+  const theme = createTheme(
+    {},
+    jaJP // x-date-pickers translations
+  );
+
+  const onChange = (date: Date | null) => {
+    setSelectedDate(dayjs(date));
+    setSchdule({ ...schedule, date: dayjs(date) });
+  };
+
+  return (
+    <form onSubmit={handleSaveSchedule}>
+      <Box
+        display="flex"
+        flexDirection="column"
+        alignItems="center"
+        width="320px"
+        marginTop="30px"
+      >
+        <ThemeProvider theme={theme}>
+          <LocalizationProvider
+            dateAdapter={DateAdapter}
+            dateFormats={{ monthAndYear: "yyyy年 MM月", monthShort: "MM月" }}
+          >
+            <DateCalendar
+              views={["day"]}
+              value={selectedDate?.toDate()}
+              maxDate={today.toDate()}
+              onChange={onChange}
+              sx={{ width: "100%", transform: "scale(0.8)" }}
+            />
+          </LocalizationProvider>
+        </ThemeProvider>
+        <TextField
+          size="small"
+          inputProps={{ style: { fontSize: 18 } }}
+          placeholder="予定"
+          value={schedule.title}
+          onChange={(e) => setSchdule({ ...schedule, title: e.target.value })}
+        />
+        <Button
+          size="small"
+          variant="outlined"
+          type="submit"
+          style={{
+            borderColor: "black",
+            borderRadius: "20px",
+            background: "#014A8F",
+          }}
+          sx={{
+            color: "white",
+            marginTop: "20px",
+            width: "120px",
+            fontSize: "20px",
+          }}
+        >
+          追加
+        </Button>
+      </Box>
+    </form>
+  );
+};

--- a/frontend/src/components/templates/MonthCalender.tsx
+++ b/frontend/src/components/templates/MonthCalender.tsx
@@ -31,62 +31,99 @@ export const MonthCalender = ({ diarys }: Props) => {
   const days = ["日", "月", "火", "水", "木", "金", "土"];
 
   return (
-    <div>
-      <Container sx={{ marginTop: "10px", width: "100%", height: "100%" }}>
-        <Grid container columns={7}>
-          {days.map((day) => (
+    <Container sx={{ marginTop: "10px", width: "100%", height: "100%" }}>
+      <Grid container columns={7}>
+        {days.map((day) => (
+          <Grid
+            item
+            display="flex"
+            justifyContent="center"
+            xs={1}
+            key={day}
+            sx={{
+              borderBottom: "1px solid #ccc",
+              textAlign: "center",
+              fontWeight: "bold",
+              color: "#666",
+            }}
+          >
+            {day}
+          </Grid>
+        ))}
+      </Grid>
+      <Grid container columns={7}>
+        {calendar.map((week: any, weekIndex: number) => (
+          <Grid
+            className="weeks"
+            item
+            xs={7}
+            key={weekIndex}
+            sx={{
+              borderBottom: "1px solid #ccc;",
+              textAlign: "right",
+              height: "130px",
+              position: "relative",
+            }}
+          >
             <Grid
-              item
-              xs={1}
-              key={day}
-              sx={{
-                borderBottom: "1px solid #ccc",
-                textAlign: "center",
-                fontWeight: "bold",
-                color: "#666",
-              }}
+              container
+              columns={7}
+              sx={{ borderLeft: "1px solid #ccc", position: "absolute" }}
             >
-              {day}
+              {week.map((item: any, dayIndex: number) => (
+                <Grid
+                  item
+                  xs={1}
+                  key={parseInt(item.date.format("DD"))}
+                  sx={{
+                    borderRight: "1px solid #ccc",
+                    borderBottom: "1px solid #ccc;",
+                    textAlign: "right",
+                    height: "130px",
+                  }}
+                ></Grid>
+              ))}
             </Grid>
-          ))}
-        </Grid>
-        <Grid container columns={7} sx={{ borderLeft: "1px solid #ccc" }}>
-          {calendar.map((item: any, index: number) => (
-            <Grid
-              className="hoge1"
-              item
-              xs={1}
-              key={index}
-              sx={{
-                borderRight: "1px solid #ccc",
-                borderBottom: "1px solid #ccc;",
-                textAlign: "right",
-                height: "130px",
-              }}
-            >
-              <Box
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setDaySelected(item.date);
-                  setShowAddDialog(true);
-                }}
-                onMouseEnter={() => setHoveredIndex(index)}
-                onMouseLeave={() => setHoveredIndex(null)}
-                sx={{ width: "100%", height: "100%" }}
-              >
-                <MonthElement
-                  key={index}
-                  index={index}
-                  hoveredIndex={hoveredIndex}
-                  day={item.date}
-                  schedules={item.schedules}
-                  diary={item.diary}
-                />
-              </Box>
+            <Grid container columns={7} sx={{ position: "absolute" }}>
+              {week.map((item: any, dayIndex: number) => (
+                <Grid
+                  item
+                  xs={1}
+                  key={parseInt(item.date.format("DD"))}
+                  sx={{
+                    textAlign: "right",
+                    height: "130px",
+                  }}
+                >
+                  <Box
+                    className="hoge3"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setDaySelected(item.date);
+                      setShowAddDialog(true);
+                    }}
+                    onMouseEnter={() => {
+                      const d = parseInt(item.date.format("MMDD"));
+                      setHoveredIndex(d);
+                    }}
+                    onMouseLeave={() => setHoveredIndex(null)}
+                    sx={{ width: "100%", height: "100%" }}
+                  >
+                    <MonthElement
+                      key={parseInt(item.date.format("MMDD"))}
+                      index={parseInt(item.date.format("MMDD"))}
+                      hoveredIndex={hoveredIndex}
+                      day={item.date}
+                      schedules={item.schedules}
+                      diary={item.diary}
+                    />
+                  </Box>
+                </Grid>
+              ))}
             </Grid>
-          ))}
-        </Grid>
-      </Container>
-    </div>
+          </Grid>
+        ))}
+      </Grid>
+    </Container>
   );
 };

--- a/frontend/src/components/templates/MonthElement.tsx
+++ b/frontend/src/components/templates/MonthElement.tsx
@@ -1,6 +1,6 @@
 import { useContext, useState } from "react";
 
-import { Box, IconButton, Typography } from "@mui/material";
+import { Box, Card, IconButton, Typography, styled } from "@mui/material";
 import NoteAltIcon from "@mui/icons-material/NoteAlt";
 import dayjs from "dayjs";
 import { useRecoilState } from "recoil";
@@ -12,6 +12,7 @@ import { scheduleType } from "@/types/schedule";
 import { MonthContext } from "@/provider/CalendarProvider";
 import { diaryType } from "@/types/diary";
 import { diaryState } from "@/atoms/diaryState";
+import { DailyDialog } from "../parts/DailyDialog";
 
 type Props = {
   index: number;
@@ -20,6 +21,13 @@ type Props = {
   schedules: scheduleType[];
   diary: diaryType;
 };
+
+const ScheduleStyle = styled(Card)(({ theme }) => ({
+  marginBottom: "4px",
+  borderRadius: "5px",
+  height: "22px",
+  background: "#fff",
+}));
 
 export const MonthElement = ({
   index,
@@ -31,6 +39,8 @@ export const MonthElement = ({
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const { setShowDialog, setSchedule } = useContext(MonthContext);
   const [currentDiary, setCurrentDiary] = useRecoilState<diaryType>(diaryState);
+
+  const [showDailyDialog, setShowDailyDialog] = useState<boolean>(false);
 
   const handleClose = () => {
     setIsOpen(false);
@@ -75,8 +85,15 @@ export const MonthElement = ({
           {day.format("D")}
         </Typography>
       </Box>
-      <Box sx={{ width: "100%", height: "80%", overflowY: "auto" }}>
-        {schedules.map((schedule: scheduleType, index: number) => (
+      <Box
+        sx={{
+          textAlign: "center",
+          marginLeft: "2.5px",
+          width: "95%",
+          height: "80%",
+        }}
+      >
+        {schedules.slice(0, 3).map((schedule: scheduleType, index: number) => (
           <Schedule
             key={index}
             schedule={schedule}
@@ -84,6 +101,27 @@ export const MonthElement = ({
             setShowDialog={setShowDialog}
           />
         ))}
+        {schedules.length > 3 && (
+          <ScheduleStyle>
+            <Box
+              onClick={(e) => {
+                e.stopPropagation();
+                setShowDailyDialog(true);
+              }}
+            >
+              <DailyDialog
+                day={day}
+                schedules={schedules}
+                setSchedule={setSchedule}
+                showDialog={showDailyDialog}
+                setShowDialog={setShowDailyDialog}
+              />
+              <Typography variant="caption" sx={{ marginRight: "10px" }}>
+                他{schedules.length - 3}件
+              </Typography>
+            </Box>
+          </ScheduleStyle>
+        )}
       </Box>
       <Diary
         day={day}

--- a/frontend/src/components/templates/MonthElement.tsx
+++ b/frontend/src/components/templates/MonthElement.tsx
@@ -113,8 +113,9 @@ export const MonthElement = ({
                 day={day}
                 schedules={schedules}
                 setSchedule={setSchedule}
-                showDialog={showDailyDialog}
-                setShowDialog={setShowDailyDialog}
+                showDailyDialog={showDailyDialog}
+                setShowDailyDialog={setShowDailyDialog}
+                setScheduleDialog={setShowDialog}
               />
               <Typography variant="caption" sx={{ marginRight: "10px" }}>
                 他{schedules.length - 3}件

--- a/frontend/src/components/templates/ProjectList.tsx
+++ b/frontend/src/components/templates/ProjectList.tsx
@@ -66,15 +66,6 @@ export const ProjectList = ({
         </Typography>
         <Button onClick={() => handleAddClick()}>追加</Button>
       </Box>
-      {/* <Box sx={{ borderBottom: "1px solid" }}>
-        <Grid container>
-          <Grid item xs={6}>
-            <Typography sx={{ marginLeft: "10px", fontSize: "18px" }}>
-              プロジェクト名
-            </Typography>
-          </Grid>
-        </Grid>
-      </Box> */}
       <Box
         sx={{
           overflowY: "auto",

--- a/frontend/src/components/views/MonthView.tsx
+++ b/frontend/src/components/views/MonthView.tsx
@@ -156,11 +156,7 @@ export const MonthView = () => {
   return (
     <div>
       <Box display="flex" flexDirection="row">
-        <AddScheduleBar
-          schedule={schedule}
-          setSchdule={setSchedule}
-          handleSaveSchedule={handleSaveSchedule}
-        />
+        <AddScheduleBar handleSaveSchedule={handleSaveSchedule} />
         <MonthCalender diarys={diarys} />
       </Box>
       <AddScheduleDialog handleSaveSchedule={handleSaveSchedule} />

--- a/frontend/src/components/views/MonthView.tsx
+++ b/frontend/src/components/views/MonthView.tsx
@@ -12,6 +12,8 @@ import { diaryType } from "@/types/diary";
 import { useRecoilState } from "recoil";
 import { diarysState } from "@/atoms/diarysState";
 import { pageState } from "@/atoms/pageState";
+import { Box } from "@mui/material";
+import { AddScheduleBar } from "../templates/AddScheduleBar";
 
 export const MonthView = () => {
   const {
@@ -153,7 +155,14 @@ export const MonthView = () => {
 
   return (
     <div>
-      <MonthCalender diarys={diarys} />
+      <Box display="flex" flexDirection="row">
+        <AddScheduleBar
+          schedule={schedule}
+          setSchdule={setSchedule}
+          handleSaveSchedule={handleSaveSchedule}
+        />
+        <MonthCalender diarys={diarys} />
+      </Box>
       <AddScheduleDialog handleSaveSchedule={handleSaveSchedule} />
       <CurrentScheduleDialog handleDelete={handleDelete} />
       <ChangeScheduleDialog handleChangeSchedule={handleChangeSchedule} />

--- a/frontend/src/libs/service/calender.ts
+++ b/frontend/src/libs/service/calender.ts
@@ -5,14 +5,16 @@ export const createCalender = (month = dayjs().month()) => {
   const firstDay = dayjs(new Date(year, month, 1));
   const firstDayIndex = firstDay.day();
 
-  return Array(35)
-    .fill(0)
-    .map((_, i) => {
-      const diffFromFirstDay = i - firstDayIndex;
+  const daysMatrix = new Array(5).fill([]).map((_, i) => {
+    return new Array(7).fill(0).map((_, j) => {
+      const diffFromFirstDay = i * 7 + j - firstDayIndex;
       const day = firstDay.add(diffFromFirstDay, "day");
 
       return day;
     });
+  });
+
+  return daysMatrix;
 };
 
 export const getStartAndEndDate = (month: dayjs.Dayjs) => {

--- a/frontend/src/libs/service/schedule.ts
+++ b/frontend/src/libs/service/schedule.ts
@@ -4,7 +4,7 @@ import { scheduleType } from "@/types/schedule";
 import dayjs from "dayjs";
 
 export const margeSchedules = (
-  calendar: dayjs.Dayjs[],
+  calendar: dayjs.Dayjs[][],
   schedules: scheduleType[],
   diarys: diaryType[]
 ) => {
@@ -14,11 +14,16 @@ export const margeSchedules = (
   if (diarys === null) {
     diarys = [];
   }
-  return calendar.map((cday: dayjs.Dayjs) => ({
-    date: cday,
-    schedules: schedules.filter((e: scheduleType) =>
-      isSameDay(dayjs(e.date), cday)
-    ),
-    diary: diarys.find((e: diaryType) => isSameDay(dayjs(e.date), cday)),
-  }));
+
+  return calendar.map((cal: dayjs.Dayjs[]) => {
+    return cal.map((cday: dayjs.Dayjs) => {
+      return {
+        date: cday,
+        schedules: schedules.filter((e: scheduleType) =>
+          isSameDay(dayjs(e.date), cday)
+        ),
+        diary: diarys.find((e: diaryType) => isSameDay(dayjs(e.date), cday)),
+      };
+    });
+  });
 };


### PR DESCRIPTION
# 概要
カレンダーページの機能追加と修正

### 追加機能＆変更
- 画面左にクイック予定追加が可能になるフォームを作成
- 4件以上の予定の確認をスクロールで行っていたが、その機能を削除しダイアログで一覧表示するように変更

### 修正
- スケジュールに関して、大きさ35の1次元配列に格納していたが5×7の2次元配列に修正